### PR TITLE
Fix mount-dirs include

### DIFF
--- a/recipes-core/images/rpi-mbed-image.bb
+++ b/recipes-core/images/rpi-mbed-image.bb
@@ -1,6 +1,6 @@
 # Base this image on rpi-basic-image
 include recipes-core/images/rpi-hwup-image.bb
-include recipes-core/mount-images/mount-images.bb
+include recipes-core/mount-dirs/mount-dirs.bb
 
 LICENSE = "Apache-2.0"
 


### PR DESCRIPTION
Fix mount-dirs file include. Wrong file caused mount directories to be missing from the image, leading to problems with FW update