### PR TITLE
Change the way u-boot is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use this layer, add following lines to your `local.conf`-file:
 
 ```
 MACHINE = "mbed-rpi3"
-KERNEL_IMAGETYPE="uImage"
+RPI_USE_U_BOOT = "1"
 #ENABLE_UART is strictly not necessary, but can help with debugging issues.
 ENABLE_UART="1"
 ```


### PR DESCRIPTION
U-boot is enabled differently in the new yocto version `sumo`